### PR TITLE
Add Aurora momentum oscillator with price forecasts

### DIFF
--- a/adaptive_mfm.pine
+++ b/adaptive_mfm.pine
@@ -1,126 +1,137 @@
 //@version=5
-indicator(title="Adaptive Multi-Factor Momentum Map", shorttitle="Adaptive MFM", overlay=false, max_bars_back=500, max_lines_count=500, max_labels_count=500)
+indicator(title="Aurora Momentum Forecast Oscillator", shorttitle="Aurora MFO", overlay=false, max_bars_back=500, max_lines_count=500, max_labels_count=500)
 
-// --- Determine adaptive regime based on chart timeframe
-defaultSeconds = 60.0
+// --- Resolve chart regime adaptively so the indicator feels natural on any timeframe
+var float _defaultSeconds = 60.0
 f_resolveSeconds() =>
-    _secs = timeframe.in_seconds(timeframe.period)
+    float _secs = timeframe.in_seconds(timeframe.period)
     if not na(_secs)
         _secs
     else
-        float _base = timeframe.multiplier * (timeframe.isintraday ? 60.0 : timeframe.isdaily ? 1440.0 * 60.0 : timeframe.isweekly ? 7.0 * 24.0 * 60.0 * 60.0 : timeframe.ismonthly ? 30.0 * 24.0 * 60.0 * 60.0 : defaultSeconds)
+        float _base = timeframe.multiplier * (timeframe.isintraday ? 60.0 : timeframe.isdaily ? 1440.0 * 60.0 : timeframe.isweekly ? 7.0 * 24.0 * 60.0 * 60.0 : timeframe.ismonthly ? 30.0 * 24.0 * 60.0 * 60.0 : _defaultSeconds)
         _base
 
-secs = math.max(defaultSeconds, f_resolveSeconds())
-mode = secs <= 60.0 ? "scalp" : secs <= 1800.0 ? "intraday" : secs <= 14400.0 ? "swing" : "position"
-rsiLen = switch mode
+float secs = math.max(_defaultSeconds, f_resolveSeconds())
+string regime = secs <= 60.0 ? "scalp" : secs <= 1800.0 ? "intraday" : secs <= 14400.0 ? "swing" : "position"
+
+int rsiLen = switch regime
     "scalp" => 7
     "intraday" => 14
     "swing" => 21
     => 28
-emaLen = switch mode
+int emaLen = switch regime
     "scalp" => 21
     "intraday" => 34
     "swing" => 55
     => 89
-stochLen = switch mode
+int stochLen = switch regime
     "scalp" => 9
     "intraday" => 14
     "swing" => 21
     => 34
-adxLen = switch mode
+int adxLen = switch regime
     "scalp" => 7
     "intraday" => 14
     "swing" => 21
     => 28
-cciLen = switch mode
+int cciLen = switch regime
     "scalp" => 14
     "intraday" => 20
     "swing" => 26
     => 34
-thresholdHigh = switch mode
-    "scalp" => 0.7
+float thresholdHigh = switch regime
+    "scalp" => 0.70
     "intraday" => 0.65
-    "swing" => 0.6
+    "swing" => 0.60
     => 0.55
-thresholdLow = switch mode
-    "scalp" => -0.7
+float thresholdLow = switch regime
+    "scalp" => -0.70
     "intraday" => -0.65
-    "swing" => -0.6
+    "swing" => -0.60
     => -0.55
 
-// --- Indicator calculations
-rsiVal = ta.rsi(close, rsiLen)
-emaFastLen = math.max(3, int(math.round(rsiLen * 0.5)))
-emaFast = ta.ema(close, emaFastLen)
-emaSlow = ta.ema(close, emaLen)
-macdVal = emaFast - emaSlow
-macdSignal = ta.ema(macdVal, emaFastLen)
-macdHist = macdVal - macdSignal
+// --- Core momentum ingredients
+float rsiVal = ta.rsi(close, rsiLen)
+int emaFastLen = math.max(3, int(math.round(rsiLen * 0.5)))
+float emaFast = ta.ema(close, emaFastLen)
+float emaSlow = ta.ema(close, emaLen)
+float macdVal = emaFast - emaSlow
+float macdSignal = ta.ema(macdVal, emaFastLen)
+float macdHist = macdVal - macdSignal
 
-k = ta.stoch(high, low, close, stochLen)
-d = ta.sma(k, 3)
-cciVal = ta.cci(high, low, close, cciLen)
-adxVal = ta.adx(adxLen)
-rocVal = ta.roc(close, rsiLen)
-atrVal = ta.atr(math.max(5, rsiLen))
+float k = ta.stoch(high, low, close, stochLen)
+float d = ta.sma(k, 3)
+float cciVal = ta.cci(high, low, close, cciLen)
+float adxVal = ta.adx(adxLen)
+float rocVal = ta.roc(close, rsiLen)
+float atrVal = ta.atr(math.max(5, rsiLen))
 
-// --- Normalise values to -1..1 range
-normRsi = (rsiVal - 50.0) / 50.0
-normMacd = math.clamp(macdHist / math.max(atrVal, 1e-6), -1.5, 1.5) / 1.5
-normStoch = ((k + d) * 0.5 - 50.0) / 50.0
-normCci = math.clamp(cciVal / 200.0, -1.0, 1.0)
-normAdx = math.clamp((adxVal - 25.0) / 25.0, -1.0, 1.0) * math.sign(emaFast - emaSlow)
-normRoc = math.clamp(rocVal / 5.0, -1.0, 1.0)
-trendDirection = math.tanh((close - emaSlow) / math.max(atrVal * 1.5, 1e-6))
+// --- Normalised into a -1..1 envelope
+float normRsi = (rsiVal - 50.0) / 50.0
+float normMacd = math.clamp(macdHist / math.max(atrVal, 1e-6), -1.5, 1.5) / 1.5
+float normStoch = ((k + d) * 0.5 - 50.0) / 50.0
+float normCci = math.clamp(cciVal / 200.0, -1.0, 1.0)
+float normAdx = math.clamp((adxVal - 25.0) / 25.0, -1.0, 1.0) * math.sign(emaFast - emaSlow)
+float normRoc = math.clamp(rocVal / 5.0, -1.0, 1.0)
+float trendDirection = math.tanh((close - emaSlow) / math.max(atrVal * 1.5, 1e-6))
 
-// --- Weightings based on regime
-weightRsi = mode == "scalp" ? 0.20 : mode == "intraday" ? 0.18 : mode == "swing" ? 0.16 : 0.15
-weightMacd = mode == "scalp" ? 0.15 : mode == "intraday" ? 0.18 : mode == "swing" ? 0.22 : 0.24
-weightStoch = mode == "scalp" ? 0.20 : mode == "intraday" ? 0.18 : mode == "swing" ? 0.16 : 0.12
-weightTrend = mode == "scalp" ? 0.15 : mode == "intraday" ? 0.16 : mode == "swing" ? 0.18 : 0.20
-weightCci = mode == "scalp" ? 0.15 : mode == "intraday" ? 0.14 : mode == "swing" ? 0.12 : 0.12
-weightRoc = mode == "scalp" ? 0.15 : mode == "intraday" ? 0.16 : mode == "swing" ? 0.16 : 0.17
+// --- Regime sensitive weighting keeps the read intuitive
+float weightRsi = regime == "scalp" ? 0.20 : regime == "intraday" ? 0.18 : regime == "swing" ? 0.16 : 0.15
+float weightMacd = regime == "scalp" ? 0.15 : regime == "intraday" ? 0.18 : regime == "swing" ? 0.22 : 0.24
+float weightStoch = regime == "scalp" ? 0.20 : regime == "intraday" ? 0.18 : regime == "swing" ? 0.16 : 0.12
+float weightTrend = regime == "scalp" ? 0.15 : regime == "intraday" ? 0.16 : regime == "swing" ? 0.18 : 0.20
+float weightCci = regime == "scalp" ? 0.15 : regime == "intraday" ? 0.14 : regime == "swing" ? 0.12 : 0.12
+float weightRoc = regime == "scalp" ? 0.15 : regime == "intraday" ? 0.16 : regime == "swing" ? 0.16 : 0.17
 
-rawWeightedScore = normRsi * weightRsi + normMacd * weightMacd + normStoch * weightStoch + trendDirection * weightTrend + normCci * weightCci + normRoc * weightRoc
-weightedScore = math.tanh(rawWeightedScore)
-smoothScore = ta.ema(weightedScore, emaFastLen)
+float rawWeightedScore = normRsi * weightRsi + normMacd * weightMacd + normStoch * weightStoch + trendDirection * weightTrend + normCci * weightCci + normRoc * weightRoc
+float weightedScore = math.tanh(rawWeightedScore)
+float smoothScore = ta.ema(weightedScore, emaFastLen)
 
-// --- Forecast future bars using linear projection
-slope = smoothScore - smoothScore[1]
-forecast1 = smoothScore + slope
-forecast2 = smoothScore + slope * 2.0
-forecast3 = smoothScore + slope * 3.0
+// --- Forward glance of momentum for faster reaction
+float slope = smoothScore - smoothScore[1]
+float scoreForecast1 = smoothScore + slope * 1.0
+float scoreForecast2 = smoothScore + slope * 2.0
+float scoreForecast3 = smoothScore + slope * 3.0
 
-// --- Signal conditions
-buySignal = ta.crossover(smoothScore, thresholdLow)
-sellSignal = ta.crossunder(smoothScore, thresholdHigh)
+// --- Average price drift gives soft forecast levels that update each bar
+int priceLookback = regime == "scalp" ? 21 : regime == "intraday" ? 34 : regime == "swing" ? 55 : 89
+float priceDrift = ta.ema(close - close[1], priceLookback)
+float priceForecast1 = close + priceDrift * 1.0
+float priceForecast2 = close + priceDrift * 2.0
+float priceForecast3 = close + priceDrift * 3.0
 
-// --- Plot oscillator and thresholds
-plotZero = plot(0, "Zero", color=color.new(color.gray, 80))
-scoreColorBase = smoothScore >= 0 ? color.teal : color.maroon
-scoreAlpha = 70 - int(math.min(60.0, math.abs(smoothScore) * 60.0))
-plotScore = plot(smoothScore, "Adaptive Score", color=scoreColorBase, linewidth=2)
+// --- Trade timing cues
+bool buySignal = ta.crossover(smoothScore, thresholdLow)
+bool sellSignal = ta.crossunder(smoothScore, thresholdHigh)
+
+// --- Oscillator visuals with shaded conviction
+float positiveScore = math.max(smoothScore, 0.0)
+float negativeScore = math.min(smoothScore, 0.0)
+plotZero = plot(0.0, "Zero", color=color.new(color.gray, 85))
+plotPos = plot(positiveScore, "Positive Momentum", color=color.new(color.teal, 0), linewidth=2)
+plotNeg = plot(negativeScore, "Negative Momentum", color=color.new(color.maroon, 0), linewidth=2)
+fill(plotPos, plotZero, color=color.new(color.teal, 80))
+fill(plotNeg, plotZero, color=color.new(color.maroon, 80))
+
+plotScore = plot(smoothScore, "Aurora Score", color=color.new(color.white, 0), linewidth=1)
 plot(thresholdHigh, "Sell Threshold", color=color.new(color.red, 60))
 plot(thresholdLow, "Buy Threshold", color=color.new(color.lime, 60))
-fill(plotScore, plotZero, color=color.new(scoreColorBase, scoreAlpha))
 
-plot(forecast1, "H1 Forecast", color=color.new(color.orange, 40), offset=1, style=plot.style_linebr)
-plot(forecast2, "H2 Forecast", color=color.new(color.orange, 55), offset=2, style=plot.style_linebr)
-plot(forecast3, "H3 Forecast", color=color.new(color.orange, 70), offset=3, style=plot.style_linebr)
+plot(scoreForecast1, "Score Forecast +1", color=color.new(color.orange, 50), offset=1, style=plot.style_linebr)
+plot(scoreForecast2, "Score Forecast +2", color=color.new(color.orange, 65), offset=2, style=plot.style_linebr)
+plot(scoreForecast3, "Score Forecast +3", color=color.new(color.orange, 80), offset=3, style=plot.style_linebr)
 
-plotshape(buySignal, title="Buy Signal", text="Buy", style=shape.labelup, color=color.new(color.green, 0), textcolor=color.white, location=location.bottom, size=size.tiny, offset=0)
-plotshape(sellSignal, title="Sell Signal", text="Sell", style=shape.labeldown, color=color.new(color.red, 0), textcolor=color.white, location=location.top, size=size.tiny, offset=0)
+plotshape(buySignal, title="Buy Signal", text="BUY", style=shape.labelup, color=color.new(color.green, 0), textcolor=color.white, location=location.bottom, size=size.tiny)
+plotshape(sellSignal, title="Sell Signal", text="SELL", style=shape.labeldown, color=color.new(color.red, 0), textcolor=color.white, location=location.top, size=size.tiny)
 
-// --- Display informative table
+bgcolor(buySignal ? color.new(color.lime, 85) : sellSignal ? color.new(color.red, 85) : na)
+
+// --- Heads-up display keeps values easy to read on mobile copy/paste
 var table infoTable = table.new(position.top_right, 1, 6, bgcolor=color.new(color.black, 85))
 if barstate.islast
-    table.cell(infoTable, 0, 0, "Mode: " + str.upper(mode), text_color=color.white)
+    table.cell(infoTable, 0, 0, "Regime: " + str.upper(regime), text_color=color.white)
     table.cell(infoTable, 0, 1, "Score: " + str.tostring(smoothScore, format.percent))
     table.cell(infoTable, 0, 2, "RSI: " + str.tostring(rsiVal, format.mintick))
-    table.cell(infoTable, 0, 3, "MACD: " + str.tostring(macdHist, format.mintick))
-    table.cell(infoTable, 0, 4, "ADX: " + str.tostring(adxVal, format.mintick))
-    table.cell(infoTable, 0, 5, "ATR: " + str.tostring(atrVal, format.mintick))
-
-// --- Highlight signals on chart background
-bgcolor(buySignal ? color.new(color.lime, 85) : sellSignal ? color.new(color.red, 85) : na)
+    table.cell(infoTable, 0, 3, "ADX: " + str.tostring(adxVal, format.mintick))
+    table.cell(infoTable, 0, 4, "Forecast Close +1: " + str.tostring(priceForecast1, format.mintick))
+    table.cell(infoTable, 0, 5, "Forecast Close +3: " + str.tostring(priceForecast3, format.mintick))


### PR DESCRIPTION
## Summary
- replace the previous momentum map with the Aurora Momentum Forecast Oscillator
- add adaptive multi-factor momentum scoring with shaded buy and sell zones
- surface short-term price drift forecasts and mobile-friendly HUD details

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f1fcdbe844832797a9187610640102