### PR TITLE
Add service worker caching and secure registration guard

### DIFF
--- a/phone-dsc-pwa/index.html
+++ b/phone-dsc-pwa/index.html
@@ -214,7 +214,13 @@
 <footer class="footer">
   <span class="footnote">If location fails, host this file over HTTPS (GitHub Pages/Netlify) or use manual/preset.</span>
 </footer>
-<script>if ('serviceWorker' in navigator){window.addEventListener('load',()=>navigator.serviceWorker.register('service-worker.js').catch(console.error));}</script>
+<script>
+  if ('serviceWorker' in navigator && window.isSecureContext) {
+    window.addEventListener('load', () =>
+      navigator.serviceWorker.register('service-worker.js').catch(console.error)
+    );
+  }
+</script>
 
 <script>
 const DEG2RAD = Math.PI/180, RAD2DEG = 180/Math.PI;

--- a/phone-dsc-pwa/service-worker.js
+++ b/phone-dsc-pwa/service-worker.js
@@ -1,0 +1,37 @@
+const CACHE_NAME = 'phone-dsc-cache-v2';
+const asset = (path) => new URL(path, self.location).toString();
+const OFFLINE_URL = asset('index.html');
+const PRECACHE_ASSETS = [asset('./'), OFFLINE_URL];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches
+      .open(CACHE_NAME)
+      .then((cache) => cache.addAll(PRECACHE_ASSETS))
+      .then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) => Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key))))
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  if (request.method !== 'GET') return;
+
+  event.respondWith(
+    fetch(request)
+      .then((response) => {
+        const copy = response.clone();
+        caches.open(CACHE_NAME).then((cache) => cache.put(request, copy));
+        return response;
+      })
+      .catch(() => caches.match(request).then((cached) => cached || caches.match(OFFLINE_URL)))
+  );
+});


### PR DESCRIPTION
## Summary
- add a minimal service worker to cache the app shell for offline usage
- only attempt service worker registration when the page is served from a secure context to avoid console errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956a45d36f083279898f9c1c2e4e316)